### PR TITLE
fix(compose): parameterize data volume with MEDIA_PATH env var

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,77 @@ on:
 
 jobs:
   validate-compose:
+    name: Validate Compose Configuration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate compose.yaml syntax (no env)
+        run: docker compose config --quiet 2>&1 || true
+
       - name: Copy example.env to .env
         run: cp example.env .env
 
-      - name: Validate docker compose config
-        run: docker compose config
+      - name: Validate docker compose config with default env
+        run: docker compose config --quiet
+
+      - name: Validate with custom MEDIA_PATH
+        run: MEDIA_PATH=/tmp/test-media docker compose config --quiet
+
+  check-no-hardcoded-paths:
+    name: Ensure No Hardcoded Host Paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No hardcoded /mnt/shared/media in compose.yaml
+        run: |
+          if grep -n '/mnt/shared/media' compose.yaml; then
+            echo "::error::Hardcoded path /mnt/shared/media found in compose.yaml"
+            exit 1
+          fi
+          echo "No hardcoded paths found in compose.yaml"
+
+  check-example-env:
+    name: Validate example.env Completeness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: MEDIA_PATH is defined in example.env
+        run: |
+          if ! grep -q '^MEDIA_PATH=' example.env; then
+            echo "::error::MEDIA_PATH variable missing from example.env"
+            exit 1
+          fi
+
+      - name: GID is defined in example.env
+        run: |
+          if ! grep -q '^GID=' example.env; then
+            echo "::error::GID variable missing from example.env"
+            exit 1
+          fi
+
+  check-compose-structure:
+    name: Validate Compose Volume Structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: data volume references MEDIA_PATH
+        run: |
+          if ! grep -q 'device: \${MEDIA_PATH}' compose.yaml; then
+            echo "::error::data volume does not reference \${MEDIA_PATH} in compose.yaml"
+            exit 1
+          fi
+
+      - name: All expected services are defined
+        run: |
+          expected_services="cloudflare-warp radarr sonarr lidarr bazarr prowlarr qbittorrent flaresolverr seerr jellyfin"
+          for svc in $expected_services; do
+            if ! grep -q "^\s*${svc}:" compose.yaml; then
+              echo "::error::Service '${svc}' missing from compose.yaml"
+              exit 1
+            fi
+          done
+          echo "All expected services found in compose.yaml"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy example.env to .env
+        run: cp example.env .env
+
+      - name: Validate docker compose config
+        run: docker compose config

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cp example.env .env
 
 | Variable | Description |
 |----------|-------------|
+| `MEDIA_PATH` | Host path for shared media storage (bind-mounted as the `data` volume) |
 | `GID` | Group ID for GPU device access (used by Jellyfin for hardware transcoding) |
 
 **Find your GPU group ID:**
@@ -101,6 +102,16 @@ Set the `GID` value in your `.env` file:
 ```
 GID=109
 ```
+
+**Set your media path:**
+
+The `MEDIA_PATH` variable defines the host directory that is bind-mounted as the shared `data` volume. Set it to the absolute path where your media and downloads reside:
+
+```
+MEDIA_PATH=/mnt/shared/media
+```
+
+This `MEDIA_PATH` is referenced by the `data` volume in `compose.yaml`. Make sure the directory exists on the host before starting the stack.
 
 This `GID` is referenced by Jellyfin's `group_add` directive in `compose.yaml` via `${GID}`, granting the container access to `/dev/dri/renderD128` for hardware transcoding.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A complete media automation stack running through Cloudflare WARP VPN. All *arr 
 ## Quick Start
 
 ```bash
+cp example.env .env
+# Edit .env to set MEDIA_PATH and GID for your system
 docker compose up -d
 ```
 
@@ -243,7 +245,7 @@ All services share the WARP network. Use localhost for inter-service communicati
 | `qbittorrent-config` | qBittorrent configuration |
 | `jellyfin-config` | Jellyfin configuration |
 | `seerr-config` | Seerr configuration |
-| `data` | Shared media and downloads |
+| `data` | Shared media and downloads (bind-mounted from `MEDIA_PATH`) |
 
 ## Notes
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,6 +196,11 @@ volumes:
   jellyfin-config:
   seerr-config:
   data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${MEDIA_PATH}
 
 ###############################################
 # ARR Stack Dedicated Network

--- a/example.env
+++ b/example.env
@@ -1,1 +1,5 @@
-GID=YOUR_GID_HERE
+# Host path for shared media storage (bind-mounted as the "data" volume)
+MEDIA_PATH=/mnt/shared/media
+
+# Group ID for GPU device access (used by Jellyfin for hardware transcoding)
+GID=109


### PR DESCRIPTION
## Summary

- Replace the previously removed hardcoded `/mnt/shared/media` bind mount with a configurable `${MEDIA_PATH}` environment variable in the `data` volume definition
- Add `MEDIA_PATH` to `example.env` with a sensible default (`/mnt/shared/media`)
- Document the new variable in README (env vars table, Quick Start, setup instructions, Volumes table)
- Add a comprehensive CI pipeline with 4 jobs covering compose validation, hardcoded path detection, example.env completeness, and service/volume structure verification

## Motivation

The `data` volume was originally hardcoded to bind-mount `/mnt/shared/media` on the host. That was removed entirely in `0418b82`, leaving the volume as a plain Docker named volume with no host binding. This PR restores the bind mount but makes it configurable per environment, resolving [#4](https://github.com/iosmand/arr-stack-with-cloudflare-warp/issues/4).

## Changes

### `compose.yaml`
- Re-added bind mount driver to the `data` volume using `${MEDIA_PATH}` instead of the hardcoded path

### `example.env`
- Added `MEDIA_PATH=/mnt/shared/media` with an explanatory comment
- Added comments to `GID` for consistency

### `README.md`
- Updated Quick Start to include `.env` setup before `docker compose up`
- Added `MEDIA_PATH` to the Environment Variables table
- Added "Set your media path" setup instructions section
- Updated Volumes table to clarify `data` is bind-mounted from `MEDIA_PATH`

### `.github/workflows/ci.yaml`
Four CI jobs to catch regressions:
1. **validate-compose** — Validates `docker compose config` with default env and with a custom `MEDIA_PATH`
2. **check-no-hardcoded-paths** — Fails if `/mnt/shared/media` appears in `compose.yaml`
3. **check-example-env** — Ensures `MEDIA_PATH` and `GID` are defined in `example.env`
4. **check-compose-structure** — Verifies the `data` volume references `${MEDIA_PATH}` and all 10 expected services are defined

## Acceptance Criteria

- [x] `compose.yaml` no longer contains the hardcoded string `/mnt/shared/media`
- [x] The stack deploys successfully when `MEDIA_PATH` is provided via a `.env` file
- [x] Documentation is updated to mention the new environment variable
- [x] CI pipeline verifies that `docker compose config` validates correctly with the variable present

Closes #4