### PR TITLE
refactor: migrate data volume from bind mount to external Docker volume

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,6 @@ jobs:
       - name: Validate docker compose config with default env
         run: docker compose config --quiet
 
-      - name: Validate with custom MEDIA_PATH
-        run: MEDIA_PATH=/tmp/test-media docker compose config --quiet
-
   check-no-hardcoded-paths:
     name: Ensure No Hardcoded Host Paths
     runs-on: ubuntu-latest
@@ -45,13 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: MEDIA_PATH is defined in example.env
-        run: |
-          if ! grep -q '^MEDIA_PATH=' example.env; then
-            echo "::error::MEDIA_PATH variable missing from example.env"
-            exit 1
-          fi
-
       - name: GID is defined in example.env
         run: |
           if ! grep -q '^GID=' example.env; then
@@ -65,10 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: data volume references MEDIA_PATH
+      - name: data volume is defined
         run: |
-          if ! grep -q 'device: \${MEDIA_PATH}' compose.yaml; then
-            echo "::error::data volume does not reference \${MEDIA_PATH} in compose.yaml"
+          if ! grep -q '^\s*data:' compose.yaml; then
+            echo "::error::data volume not defined in compose.yaml"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A complete media automation stack running through Cloudflare WARP VPN. All *arr 
 
 ```bash
 cp example.env .env
-# Edit .env to set MEDIA_PATH and GID for your system
+# Edit .env to set GID for your system
+docker volume create data
 docker compose up -d
 ```
 
@@ -66,7 +67,13 @@ After deployment, access services at:
 
 ### Data Volume Structure
 
-All services share a common `/data` volume. Recommended structure:
+All services share a common external `data` volume mounted at `/data`. This volume must be created once before the first start and is not removed by `docker compose down`:
+
+```bash
+docker volume create data
+```
+
+Recommended directory structure inside the volume:
 
 ```
 /data
@@ -80,6 +87,20 @@ All services share a common `/data` volume. Recommended structure:
     └── music/
 ```
 
+To seed the volume with existing files, run a disposable container that mounts it:
+
+```bash
+docker run --rm -v data:/data -v /path/on/host:/source alpine sh -c "cp -r /source/. /data/"
+```
+
+To find the volume's on-disk location:
+
+```bash
+docker volume inspect data --format '{{ .Mountpoint }}'
+```
+
+> **Note:** Because the volume is external, `docker compose down` will not remove it. To delete it, run `docker volume rm data` manually.
+
 ### Environment Variables
 
 Copy `example.env` to `.env` and configure the values:
@@ -90,7 +111,6 @@ cp example.env .env
 
 | Variable | Description |
 |----------|-------------|
-| `MEDIA_PATH` | Host path for shared media storage (bind-mounted as the `data` volume) |
 | `GID` | Group ID for GPU device access (used by Jellyfin for hardware transcoding) |
 
 **Find your GPU group ID:**
@@ -104,16 +124,6 @@ Set the `GID` value in your `.env` file:
 ```
 GID=109
 ```
-
-**Set your media path:**
-
-The `MEDIA_PATH` variable defines the host directory that is bind-mounted as the shared `data` volume. Set it to the absolute path where your media and downloads reside:
-
-```
-MEDIA_PATH=/mnt/shared/media
-```
-
-This `MEDIA_PATH` is referenced by the `data` volume in `compose.yaml`. Make sure the directory exists on the host before starting the stack.
 
 This `GID` is referenced by Jellyfin's `group_add` directive in `compose.yaml` via `${GID}`, granting the container access to `/dev/dri/renderD128` for hardware transcoding.
 
@@ -245,12 +255,13 @@ All services share the WARP network. Use localhost for inter-service communicati
 | `qbittorrent-config` | qBittorrent configuration |
 | `jellyfin-config` | Jellyfin configuration |
 | `seerr-config` | Seerr configuration |
-| `data` | Shared media and downloads (bind-mounted from `MEDIA_PATH`) |
+| `data` | Shared media and downloads (external volume) |
 
 ## Notes
 
 - WARP runs as a **non-registered (free) user**
 - Registration data persists in Docker volume to avoid re-registering on restart
 - All *arr services wait for WARP to be healthy before starting
+- The `data` volume is **external** — it must be created before the first `docker compose up` and is not removed by `docker compose down`
 - Jellyfin has read-only access to the data volume (`:ro`)
 - Port 7359/UDP is for Jellyfin auto-discovery on local network

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,11 +196,7 @@ volumes:
   jellyfin-config:
   seerr-config:
   data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${MEDIA_PATH}
+    external: true
 
 ###############################################
 # ARR Stack Dedicated Network

--- a/example.env
+++ b/example.env
@@ -1,5 +1,2 @@
-# Host path for shared media storage (bind-mounted as the "data" volume)
-MEDIA_PATH=/mnt/shared/media
-
 # Group ID for GPU device access (used by Jellyfin for hardware transcoding)
 GID=109


### PR DESCRIPTION
## Summary
- Replace `MEDIA_PATH` host bind mount with an external Docker-managed volume (`external: true`)
- Remove all `MEDIA_PATH` references from `compose.yaml`, `example.env`, `.env`, CI workflow, and README
- Add `docker volume create data` to Quick Start and volume seeding instructions to README
- Simplify CI workflow by removing MEDIA_PATH validation steps

## Motivation
The bind-mount approach required every user to configure `MEDIA_PATH` and ensure the host directory existed. An external Docker volume eliminates this host-path dependency, simplifies onboarding, and follows Docker Compose best practices for shared persistent data.

## Breaking Changes
- **Users must create the `data` volume before the first run:** `docker volume create data`
- The `.env` file no longer needs a `MEDIA_PATH` variable
- Existing data in the old bind-mounted path must be migrated into the new volume manually

## Files Changed
- `compose.yaml` — `data` volume changed to `external: true` (no more `driver_opts` bind mount)
- `example.env` / `.env` — `MEDIA_PATH` variable removed
- `.github/workflows/ci.yaml` — MEDIA_PATH validation steps removed
- `README.md` — Updated Quick Start, Data Volume Structure, Environment Variables, Volumes table, and Notes